### PR TITLE
add dollar sign to list of special characters

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -91,7 +91,7 @@ function getValidKey({ key, verbose = false }) {
   // Replace invalid characters
   if (!NAME_RX.test(nkey)) {
     changed = true
-    nkey = nkey.replace(/-|__|:|\.|\s/g, `_`)
+    nkey = nkey.replace(/-|__|:|\$|\.|\s/g, '_');
   }
   // Prefix if first character isn't a letter.
   if (!NAME_RX.test(nkey.slice(0, 1))) {
@@ -100,7 +100,7 @@ function getValidKey({ key, verbose = false }) {
   }
   if (restrictedNodeFields.includes(nkey)) {
     changed = true
-    nkey = `${conflictFieldPrefix}${nkey}`.replace(/-|__|:|\.|\s/g, `_`)
+    nkey = `${conflictFieldPrefix}${nkey}`.replace(/-|__|:|\$|\.|\s/g, '_');
   }
   if (changed && verbose)
     log(chalk`{bgCyan Plugin ApiServer} Object with key "${key}" breaks GraphQL naming convention. Renamed to "${nkey}"`)


### PR DESCRIPTION
I was having an issue with an object property with `$` in the name. It seems like adding `$` to the list of special characters.

I put a more in-depth explanation on Stack Overflow: https://stackoverflow.com/questions/51213706/gatsby-source-api-server-converting-name-of-property-and-not-allowing-graphql-qu/51214289#51214289