### PR TITLE
`contentDigest` only depends on the data, not the id

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -57,17 +57,14 @@ exports.sourceNodes = async ({
     return
   }
 
-  // Standardize and clean keys
-  entities = normalize.standardizeKeys(entities)
-
-  // Add entity type to each entity
-  entities = normalize.createEntityType(entityType, entities)
-
-  // Create a unique id for gatsby
-  entities = normalize.createGatsbyIds(createNodeId, idField, entities, reporter)
-
   // Generate the nodes
-  normalize.createNodesFromEntities({entities, entityType, schemaType, createNode, reporter})
+  normalize.createNodesFromEntities({
+      entities,
+      entityType,
+      schemaType,
+      createNode,
+      createNodeId,
+      reporter})
 
   // We're done, return.
   return


### PR DESCRIPTION
ContentDigest should only change when the data changes so we should not include the randomly generated gatsby id when computing it.
Use case: If the user needs to know whether the data has changed since the last time the app was built, they want to use `contentDigest`.

I have thus moved code from `gatsby-node.js` into `normalize.js` so that we can add the `id` after we have computed the digest of the (normalized) data. (I also exclude `__type` from the digest, though it doesn't really matter. And there are few tiny code improementes such as let -> const.)