### PR TITLE
Fix dummy id

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -50,7 +50,7 @@ exports.createNodesFromEntities = ({entities, entityType, schemaType, createNode
 
     const node = {
       ...entity,
-      id: createGatsbyId(createNodeId),
+      id: entity.id === 'dummy' ? 'dummy' : createGatsbyId(createNodeId),
       parent: null,
       children: [],
       mediaType: 'application/json',


### PR DESCRIPTION
The `dummy` id was overridden systematically by `createGatsbyId`.
Bug described in #16