### PR TITLE
WIP: feat: delete nodes when running in preview mode

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -35,7 +35,7 @@ exports.sourceNodes = async ({
 }) => {
   //store the attributes in an object to avoid naming conflicts
   const attributes = {typePrefix, url, method, headers, data, localSave, skipCreateNode, path, auth, params, payloadKey, name, entityLevel, schemaType, enableDevRefresh, refreshId}
-  const { createNode } = actions;
+  const { createNode, deleteNode } = actions;
 
   // If true, output some info as the plugin runs
   let verbose = verboseOutput
@@ -72,7 +72,7 @@ exports.sourceNodes = async ({
     const params = entity.params ? entity.params : attributes.params
     const payloadKey = entity.payloadKey ? entity.payloadKey : attributes.payloadKey
     const name = entity.name ? entity.name : attributes.name
-    const entityLevel = entity.entityLevel ? entity.entityLevel : attributes.entityLevel 
+    const entityLevel = entity.entityLevel ? entity.entityLevel : attributes.entityLevel
     const schemaType = entity.schemaType ? entity.schemaType : attributes.schemaType
     const enableDevRefresh = entity.enableDevRefresh ? entity.enableDevRefresh : attributes.enableDevRefresh
     const refreshId = entity.refreshId ? entity.refreshId : attributes.refreshId
@@ -107,6 +107,10 @@ exports.sourceNodes = async ({
       return
     }
 
+    const existingNodes = getNodes().filter(
+      n => n.internal.owner === `gatsby-source-apiserver`
+    )
+
     // Generate the nodes
     normalize.createNodesFromEntities({
         entities,
@@ -117,7 +121,9 @@ exports.sourceNodes = async ({
         refreshId,
         createNode,
         createNodeId,
-        reporter})
+        reporter,
+        existingNodes,
+        deleteNode})
 
     })
 


### PR DESCRIPTION
Hello!
Thanks for this handy Gatsby plugin. We are using it for prototype only yet but we can imagine using it in production too. We use a refresh endpoint (so mode is `devRefresh && enableRefreshEndpoint`) and all api updates are properly reflected. There is one catch: deleted items are ignored and stay as nodes in Gatsby. You have to manage this manually in the plugin. I tried an idiomatic approach to delete them and it looks good from what I see in data layer.  

The data layer is fine but the pages derived from those deleted nodes are only removed at any second call of the refresh endpoint (without calling deletePage at any of my places). I think Gatsby needs an extra round to detect the unused nodes and maybe I'm missing an explicit way of telling Gatsby to check for deleted pages.

What do you think about the change?

The PR should be considered work in progress so please don't accept and merge. I developed it by monkey patching the compiled files in node_modules and cherry picked the changes into this branch now to get a second opinion.