### PR TITLE
Paginated responses will be run through 'entityLevel' setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
 /__tests__
-/*.js
 !index.js
 tags

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,136 @@
+let doFetch = (() => {
+  var _ref = _asyncToGenerator(function* (method, url, headers, data, params, auth, reporter, routeData, calculateNextPage) {
+    let completeResult = [];
+    let haveMorePages = false;
+    let curUrl = url;
+    let context = {};
+    let didPage = false;
+
+    do {
+      let options = {
+        method: method,
+        url: curUrl,
+        headers: headers,
+        data: data,
+        params: params
+      };
+      if (auth) {
+        options.auth = auth;
+      }
+      reporter.verbose(`loading from server ${curUrl}`);
+      const response = yield axios(options);
+      reporter.verbose(`got url ${curUrl}`);
+      routeData = response.data;
+
+      haveMorePages = false; // needs to be set to true below
+      if (routeData) {
+        completeResult.push(routeData);
+        if (calculateNextPage) {
+          try {
+            const nextPage = calculateNextPage(curUrl, response, context);
+            if (nextPage.hasNext) {
+              didPage = true;
+              haveMorePages = nextPage.hasNext;
+              curUrl = nextPage.url;
+              reporter.verbose(`have more data, next page ${curUrl}`);
+            }
+          } catch (e) {
+            reporter.error(`error during calculateNextPage for url ${curUrl}`, e);
+          }
+        }
+      }
+    } while (haveMorePages);
+
+    return didPage ? completeResult : routeData;
+  });
+
+  return function doFetch(_x, _x2, _x3, _x4, _x5, _x6, _x7, _x8, _x9) {
+    return _ref.apply(this, arguments);
+  };
+})();
+
+let fetch = (() => {
+  var _ref2 = _asyncToGenerator(function* ({
+    url,
+    method,
+    headers,
+    data,
+    name,
+    localSave,
+    path,
+    payloadKey,
+    auth,
+    params,
+    verbose,
+    reporter,
+    cache,
+    useCache,
+    shouldCache,
+    maxCacheDurationSeconds,
+    calculateNextPage
+  }) {
+
+    let allRoutes;
+    let routeData;
+
+    // Attempt to download the data from api
+    routeData = useCache && (yield cache.get(url));
+
+    if (payloadKey && calculateNextPage) {
+      reporter.panic('payloadKey and calculateNextPage currently dont work together yet', new Error('payloadKey and calculateNextPage currently dont work together yet'));
+    }
+    if (!routeData) {
+
+      try {
+        routeData = yield doFetch(method, url, headers, data, params, auth, reporter, routeData, calculateNextPage);
+        if (shouldCache) {
+          yield cache.set(url, routeData);
+          yield cache.set('cacheTimestamp', new Date().toISOString());
+        }
+      } catch (e) {
+        console.log('\nGatsby Source Api Server response error:\n', e.response.data && e.response.data.errors);
+        httpExceptionHandler(e, reporter);
+      }
+    } else {
+      reporter.verbose(`using cached data for ${url}`);
+    }
+
+    if (routeData) {
+      // console.log(`allRoutes: `, allRoutes.data);
+
+      // Create a local save of the json data in the user selected path
+      if (localSave) {
+        try {
+          fs.writeFileSync(`${path}${name}.json`, stringify(routeData, null, 2));
+        } catch (err) {
+          reporter.panic(`Plugin ApiServer could not save the file.  Please make sure the folder structure is already in place.`, err);
+        }
+
+        if (verbose) {
+          log(chalk`{bgCyan.black Plugin ApiServer} ${name}.json was saved locally to ${path}`);
+        }
+      }
+
+      // Return just the intended data
+      if (payloadKey) {
+        return routeData[payloadKey];
+      }
+      return routeData;
+    }
+  });
+
+  return function fetch(_x10) {
+    return _ref2.apply(this, arguments);
+  };
+})();
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+const axios = require(`axios`);
+const fs = require('fs');
+const stringify = require(`json-stringify-safe`);
+const httpExceptionHandler = require(`./http-exception-handler`);
+const chalk = require('chalk');
+const log = console.log;
+
+module.exports = fetch;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,165 @@
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+require('babel-polyfill');
+
+const axios = require('axios');
+const fetch = require(`./fetch`);
+const normalize = require(`./normalize`);
+const objectRef = require(`./helpers`).objectRef;
+const forEachAsync = require('./helpers').forEachAsync;
+
+// const typePrefix = `thirdParty__`
+
+exports.sourceNodes = (() => {
+  var _ref = _asyncToGenerator(function* ({
+    actions,
+    createNodeId,
+    reporter,
+    getCache
+  }, {
+    typePrefix = '',
+    url,
+    method = 'get',
+    headers = {},
+    data,
+    localSave = false,
+    skipCreateNode = false,
+    path,
+    auth = false,
+    auth0Config = false,
+    payloadKey,
+    name,
+    entityLevel,
+    schemaType,
+    entitiesArray = [{}],
+    params = {},
+    verboseOutput = false,
+    enableDevRefresh = false,
+    refreshId = 'id',
+    allowCache = false,
+    maxCacheDurationSeconds = 60 * 60 * 24
+  }) {
+    //store the attributes in an object to avoid naming conflicts
+    const attributes = { typePrefix, url, method, headers, data, localSave, skipCreateNode, path, auth, params, payloadKey, name, entityLevel, schemaType, enableDevRefresh, refreshId };
+    const { createNode } = actions;
+
+    // If true, output some info as the plugin runs
+    let verbose = verboseOutput;
+
+    let authorization;
+    if (auth0Config) {
+      console.time('\nAuthenticate user');
+      // Make API request.
+      try {
+        const loginResponse = yield axios(auth0Config);
+
+        if (loginResponse.hasOwnProperty('data')) {
+          authorization = 'Bearer ' + loginResponse.data.id_token;
+        }
+      } catch (error) {
+        console.error('\nEncountered authentication error: ' + error);
+      }
+      console.timeEnd('\nAuthenticate user');
+    }
+
+    const cache = getCache('gatsby-source-apiserver');
+
+    let useCache = allowCache;
+    if (allowCache) {
+      const cacheTimestamp = yield cache.get('cacheTimestamp');
+      if (cacheTimestamp) {
+        const cacheDate = new Date(cacheTimestamp);
+        const cacheMillis = cacheDate.getTime();
+        const ageInMillis = Date.now() - cacheMillis;
+        useCache = ageInMillis < maxCacheDurationSeconds * 1000;
+        if (!useCache) {
+          reporter.info(`not using cache as its too old ${ageInMillis / 1000}s`);
+        }
+      }
+    }
+
+    yield forEachAsync(entitiesArray, (() => {
+      var _ref2 = _asyncToGenerator(function* (entity) {
+
+        // default to the general properties for any props not provided
+
+        const typePrefix = entity.typePrefix ? entity.typePrefix : attributes.typePrefix;
+        const url = entity.url ? entity.url : attributes.url;
+        const method = entity.method ? entity.method : attributes.method;
+        const headers = entity.headers ? entity.headers : attributes.headers;
+        const data = entity.data ? entity.data : attributes.data;
+        const localSave = entity.localSave ? entity.localSave : attributes.localSave;
+        const skipCreateNode = entity.skipCreateNode ? entity.skipCreateNode : attributes.skipCreateNode;
+        const calculateNextPage = entity.calculateNextPage ? entity.calculateNextPage : attributes.calculateNextPage;
+        const path = entity.path ? entity.path : attributes.path;
+        const auth = entity.auth ? entity.auth : attributes.auth;
+        const params = entity.params ? entity.params : attributes.params;
+        const payloadKey = entity.payloadKey ? entity.payloadKey : attributes.payloadKey;
+        const name = entity.name ? entity.name : attributes.name;
+        const entityLevel = entity.entityLevel ? entity.entityLevel : attributes.entityLevel;
+        const schemaType = entity.schemaType ? entity.schemaType : attributes.schemaType;
+        const enableDevRefresh = entity.enableDevRefresh ? entity.enableDevRefresh : attributes.enableDevRefresh;
+        const refreshId = entity.refreshId ? entity.refreshId : attributes.refreshId;
+
+        if (authorization) headers.Authorization = authorization;
+        // Create an entity type from prefix and name supplied by user
+        let entityType = `${typePrefix}${name}`;
+        // console.log(`entityType: ${entityType}`);
+
+        // Determine whether to refresh data when running `gatsby develop`
+        const devRefresh = process.env.NODE_ENV === 'development' && enableDevRefresh;
+        const enableRefreshEndpoint = process.env.ENABLE_GATSBY_REFRESH_ENDPOINT;
+
+        // Fetch the data
+        let entities = yield fetch({ url, method, headers, data, name, localSave, path, payloadKey, auth, params, verbose, reporter, cache, useCache, shouldCache: allowCache, maxCacheDurationSeconds, calculateNextPage });
+
+        // Interpolate entities from nested response
+        if (entityLevel) {
+          if (Array.isArray(entities)) {
+            entities = entities.reduce(function (acc, cur) {
+              return [...acc, ...objectRef(cur, entityLevel)];
+            }, []);
+          } else {
+            entities = objectRef(entities, entityLevel);
+          }
+        }
+
+        // If entities is a single object, add to array to prevent issues with creating nodes
+        if (entities && !Array.isArray(entities)) {
+          entities = [entities];
+        }
+
+        // console.log(`save: `, localSave);
+        // console.log(`entities: `, entities.data);
+
+        // Skip node creation if the goal is to only download the data to json files
+        if (skipCreateNode) {
+          return;
+        }
+
+        // Generate the nodes
+        normalize.createNodesFromEntities({
+          entities,
+          entityType,
+          schemaType,
+          devRefresh,
+          enableRefreshEndpoint,
+          refreshId,
+          createNode,
+          createNodeId,
+          reporter });
+      });
+
+      return function (_x3) {
+        return _ref2.apply(this, arguments);
+      };
+    })());
+
+    // We're done, return.
+    return;
+  });
+
+  return function (_x, _x2) {
+    return _ref.apply(this, arguments);
+  };
+})();

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,21 @@
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+exports.objectRef = (obj, str) => {
+  const levels = str.split('.');
+  for (var i = 0; i < levels.length; i++) {
+    obj = obj[levels[i]];
+  }
+  return obj;
+};
+
+exports.forEachAsync = (() => {
+  var _ref = _asyncToGenerator(function* (array, callback) {
+    for (let i = 0; i < array.length; i++) {
+      yield callback(array[i], i, array);
+    }
+  });
+
+  return function (_x, _x2) {
+    return _ref.apply(this, arguments);
+  };
+})();

--- a/http-exception-handler.js
+++ b/http-exception-handler.js
@@ -1,0 +1,24 @@
+const chalk = require('chalk');
+const log = console.log;
+
+/**
+ * Handles HTTP Exceptions (axios)
+ *
+ * @param {any} e
+ */
+
+function httpExceptionHandler(e, reporter) {
+  const { response, code } = e;
+  if (!response) {
+    log(chalk`{bgRed Plugin ApiServer} The request failed. Error Code: ${code}`);
+    return reporter.error(`Plugin ApiServer http request failed. Error Code: ${code}`, e);
+  }
+  const { status, statusText, data: { message } } = e.response;
+  log(chalk`\n{bgRed Plugin ApiServer} The server response was "${status} ${statusText}"`);
+  if (message) {
+    log(chalk`{bgRed Plugin ApiServer} Inner exception message : "${message}"`);
+  }
+  return reporter.error(`Plugin ApiServer http request failed. The server response was "${status} ${statusText}"`, e);
+}
+
+module.exports = httpExceptionHandler;

--- a/normalize.js
+++ b/normalize.js
@@ -1,0 +1,147 @@
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+const crypto = require(`crypto`);
+const stringify = require(`json-stringify-safe`);
+const deepMapKeys = require(`deep-map-keys`);
+const nanoid = require(`nanoid`);
+const chalk = require('chalk');
+const log = console.log;
+
+/**
+ * Encrypts a String using md5 hash of hexadecimal digest.
+ *
+ * @param {any} str
+ */
+const digest = str => crypto.createHash(`md5`).update(str).digest(`hex`);
+
+// Prefix to use if there is a conflict with key name
+const conflictFieldPrefix = `alternative_`;
+
+// Keys that will conflic with graphql
+const restrictedNodeFields = [`id`, `children`, `parent`, `fields`, `internal`];
+
+// Create nodes from entities
+exports.createNodesFromEntities = ({ entities, entityType, schemaType, devRefresh, enableRefreshEndpoint, refreshId, createNode, createNodeId, reporter }) => {
+
+  // Standardize and clean keys
+  entities = standardizeKeys(entities);
+
+  // Add entity type to each entity
+  entities = createEntityType(entityType, entities);
+
+  const dummyEntity = _extends({
+    id: 'dummy',
+    __type: entityType
+  }, schemaType);
+  entities.push(dummyEntity);
+
+  // warn if setting `enableDevRefresh` but not `ENABLE_GATSBY_REFRESH_ENDPOINT`
+  if (devRefresh && !enableRefreshEndpoint) {
+    log(chalk`{bgCyan.black Plugin ApiServer} {yellow warning} enableDevRefresh only works with ENABLE_GATSBY_REFRESH_ENDPOINT enabled.\n{bgCyan.black Plugin ApiServer} see https://www.gatsbyjs.org/docs/environment-variables/#reserved-environment-variables`);
+  }
+
+  entities.forEach(e => {
+    const { __type } = e,
+          entity = _objectWithoutProperties(e, ['__type']);
+
+    // if (schemaType) {
+    //   const fieldNames = Object.keys(entity)
+    //   fieldNames.forEach(fieldName => {
+    //     entity[fieldName] = setBlankValue(schemaType[fieldName], entity[fieldName])
+    //   })
+    // }
+
+    let id = entity.id === 'dummy' ? 'dummy' : createGatsbyId(createNodeId);
+
+    // override ID for dev refresh
+    // see https://github.com/gatsbyjs/gatsby/issues/14653
+    if (devRefresh && enableRefreshEndpoint) {
+      if (restrictedNodeFields.includes(refreshId)) {
+        refreshId = `${conflictFieldPrefix}${refreshId}`;
+      }
+      if (entity[refreshId]) {
+        id = entity[refreshId];
+      }
+    }
+
+    const node = _extends({}, entity, {
+      id: id,
+      parent: null,
+      children: [],
+      internal: {
+        type: __type,
+        mediaType: 'application/json',
+        contentDigest: digest(JSON.stringify(entity))
+      }
+    });
+    // console.log(`node: `, node);
+    createNode(node);
+  });
+};
+
+// If entry is not set by user, provide an empty value of the same type
+const setBlankValue = (shemaValue, fieldValue) => {
+  if (typeof shemaValue === 'string') {
+    return typeof fieldValue === `undefined` || fieldValue === null ? '' : fieldValue;
+  } else if (typeof shemaValue === 'number') {
+    return typeof fieldValue === `undefined` || fieldValue === null ? NaN : fieldValue;
+  } else if (typeof shemaValue === 'object' && !Array.isArray(shemaValue)) {
+    const obj = typeof fieldValue === `undefined` || fieldValue === null ? {} : fieldValue;
+    Object.keys(shemaValue).forEach(itemName => {
+      obj[itemName] = setBlankValue(shemaValue[itemName]);
+    });
+    return obj;
+  } else if (typeof shemaValue === 'object' && Array.isArray(shemaValue)) {
+    // TODO: Need to fix it
+    return [setBlankValue(shemaValue[0])];
+  } else if (typeof shemaValue === 'boolean') {
+    return typeof fieldValue === `undefined` || fieldValue === null ? false : fieldValue;
+  } else {
+    return fieldValue;
+  }
+};
+
+/**
+ * Validate the GraphQL naming convetions & protect specific fields.
+ *
+ * @param {any} key
+ * @returns the valid name
+ */
+function getValidKey({ key, verbose = false }) {
+  let nkey = String(key);
+  const NAME_RX = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+  let changed = false;
+  // Replace invalid characters
+  if (!NAME_RX.test(nkey)) {
+    changed = true;
+    nkey = nkey.replace(/-|__|:|\$|\.|\s/g, '_');
+  }
+  // Prefix if first character isn't a letter.
+  if (!NAME_RX.test(nkey.slice(0, 1))) {
+    changed = true;
+    nkey = `${conflictFieldPrefix}${nkey}`;
+  }
+  if (restrictedNodeFields.includes(nkey)) {
+    changed = true;
+    nkey = `${conflictFieldPrefix}${nkey}`.replace(/-|__|:|\$|\.|\s/g, '_');
+  }
+  if (changed && verbose) log(chalk`{bgCyan.black Plugin ApiServer} Object with key "${key}" breaks GraphQL naming convention. Renamed to "${nkey}"`);
+
+  return nkey;
+}
+
+exports.getValidKey = getValidKey;
+
+// Standardize ids + make sure keys are valid.
+const standardizeKeys = entities => entities.map(e => deepMapKeys(e, key => key === `ID` ? getValidKey({ key: `id` }) : getValidKey({ key })));
+
+// Generate a unique id for each entity
+const createGatsbyId = createNodeId => createNodeId(`${nanoid()}`);
+
+// Add entity type to each entity
+const createEntityType = (entityType, entities) => entities.map(e => {
+  e.__type = entityType;
+  return e;
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/thinhle-agilityio/gatsby-source-apiserver.git"
+    "url": "https://github.com/AbeCole/gatsby-source-apiserver.git"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -92,7 +92,7 @@ exports.sourceNodes = async ({
     const params = entity.params ? entity.params : attributes.params
     const payloadKey = entity.payloadKey ? entity.payloadKey : attributes.payloadKey
     const name = entity.name ? entity.name : attributes.name
-    const entityLevel = entity.entityLevel ? entity.entityLevel : attributes.entityLevel 
+    const entityLevel = entity.entityLevel ? entity.entityLevel : attributes.entityLevel
     const schemaType = entity.schemaType ? entity.schemaType : attributes.schemaType
     const enableDevRefresh = entity.enableDevRefresh ? entity.enableDevRefresh : attributes.enableDevRefresh
     const refreshId = entity.refreshId ? entity.refreshId : attributes.refreshId
@@ -112,7 +112,14 @@ exports.sourceNodes = async ({
 
     // Interpolate entities from nested response
     if (entityLevel) {
-      entities = objectRef(entities, entityLevel)
+      if (Array.isArray(entities)) {
+        entities = entities.reduce(
+          (acc, cur) => [...acc, ...objectRef(cur, entityLevel)],
+          []
+        )
+      } else {
+        entities = objectRef(entities, entityLevel)
+      }
     }
 
     // If entities is a single object, add to array to prevent issues with creating nodes


### PR DESCRIPTION
I was trying to use 'entitiesArray' with 'calculateNextPage' and ran into an issue where `entityLevel` was not being interpreted for each of the 'pages' returned by the individual fetches.