### PR TITLE
fix: add missing dependency babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "babel-cli": "^6.26.0",
+    "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.26.0",
     "chalk": "^2.3.2",
     "deep-map-keys": "^1.2.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`gatsby-source-apiserver` depends on `babel-polyfill` but doesn't declare it as a dependency

**How did you fix it?**

Added the missing dependency