### PR TITLE
Fix caching conflict when using multiple configs with the same URL

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -36,6 +36,7 @@ exports.sourceNodes = async ({
   allowCache = false,
   maxCacheDurationSeconds = 60 * 60 * 24
 }) => {
+  const cache = getCache('gatsby-source-apiserver')
   //store the attributes in an object to avoid naming conflicts
   const attributes = {typePrefix, url, method, headers, data, localSave, skipCreateNode, path, auth, params, payloadKey, name, entityLevel, schemaType, enableDevRefresh, refreshId}
   const { createNode } = actions;
@@ -57,22 +58,6 @@ exports.sourceNodes = async ({
       console.error('\nEncountered authentication error: ' + error);
     }
     console.timeEnd('\nAuthenticate user');
-  }
-
-  const cache = getCache('gatsby-source-apiserver')
-
-  let useCache = allowCache
-  if (allowCache) {
-    const cacheTimestamp = await cache.get('cacheTimestamp')
-    if (cacheTimestamp) {
-      const cacheDate = new Date(cacheTimestamp)
-      const cacheMillis = cacheDate.getTime()
-      const ageInMillis = Date.now() - cacheMillis
-      useCache = ageInMillis < (maxCacheDurationSeconds * 1000)
-      if (!useCache) {
-        reporter.info(`not using cache as its too old ${ageInMillis / 1000}s`)
-      }
-    }
   }
 
   await forEachAsync(entitiesArray, async (entity) => {
@@ -108,7 +93,7 @@ exports.sourceNodes = async ({
 
 
     // Fetch the data
-    let entities = await fetch({url, method, headers, data, name, localSave, path, payloadKey, auth, params, verbose, reporter, cache, useCache, shouldCache: allowCache, maxCacheDurationSeconds, calculateNextPage})
+    let entities = await fetch({url, method, headers, data, name, localSave, path, payloadKey, auth, params, verbose, reporter, cache, shouldCache: allowCache, maxCacheDurationSeconds, calculateNextPage})
 
     // Interpolate entities from nested response
     if (entityLevel) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,5 @@
+const crypto = require(`crypto`)
+
 exports.objectRef = (obj, str) => {
   const levels = str.split('.');
   for (var i = 0; i < levels.length; i++) {
@@ -10,4 +12,13 @@ exports.forEachAsync = async (array, callback) => {
   for (let i = 0; i < array.length; i++) {
     await callback(array[i], i, array);
   }
+}
+
+/**
+ * Encrypts a String using md5 hash of hexadecimal digest.
+ *
+ * @param {any} str
+ */
+exports.digest = str => {
+  return crypto.createHash(`md5`).update(str).digest(`hex`);
 }

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -1,20 +1,9 @@
-const crypto = require(`crypto`)
 const stringify = require(`json-stringify-safe`)
 const deepMapKeys = require(`deep-map-keys`)
 const nanoid = require(`nanoid`)
 const chalk = require('chalk')
 const log = console.log
-
-/**
- * Encrypts a String using md5 hash of hexadecimal digest.
- *
- * @param {any} str
- */
-const digest = str =>
-  crypto
-    .createHash(`md5`)
-    .update(str)
-    .digest(`hex`)
+const { digest } = require('./helpers')
 
 // Prefix to use if there is a conflict with key name
 const conflictFieldPrefix = `alternative_`


### PR DESCRIPTION
If you try to use gatsby-source-apiserver for a source that uses the same URL but different data/parameters/auth you will find that the caching will not work because it only keys off of the URL and none of those other request details.

This improves the caching strategy by writing out a cacheKey using the url, method, headers, data, name, path, payloadKey, auth, and params. It also writes out the cache timeout for each request as a separate key, instead of having all requests share a single key.